### PR TITLE
Build  exit non zero on failure

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -8,9 +8,9 @@ const {init} = require('./commands/init');
 
 // Make sure we die if we have an unhandled rejection (like a webpack build
 // failure)
-process.on("unhandledRejection", (err) => {
+process.on('unhandledRejection', (err) => {
   console.error(err);
-  process.exit(1);
+  throw new Error(`[packer-cli] ${err}`);
 });
 
 switch (process.argv[2]) {

--- a/cli/index.js
+++ b/cli/index.js
@@ -6,6 +6,13 @@ const chalk = require('chalk');
 const version = require('../package').version;
 const {init} = require('./commands/init');
 
+// Make sure we die if we have an unhandled rejection (like a webpack build
+// failure)
+process.on("unhandledRejection", (err) => {
+  console.error(err);
+  process.exit(1);
+});
+
 switch (process.argv[2]) {
   case 'init':
     init(args);


### PR DESCRIPTION
Previously, a build failure would print the webpack errors, but exit 0
(with an unhandled promise rejection warning).

Note: this was true on node 10, not sure of the other platforms.

<!-- PULL REQUEST TEMPLATE -->

**What kind of change does this PR introduce?** (check at least one)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, _not_ the `master` branch