### PR TITLE
Feature/basic pdp collection script for all duplicates

### DIFF
--- a/packer.schema.js
+++ b/packer.schema.js
@@ -9,4 +9,6 @@ module.exports = {
   'network.reload': 0,
   'build.sharedBundles': false,
   'build.sharedVendorBundles': false,
+  'build.baseProductModule': false,
+  'build.baseCollectionModule': false,
 };

--- a/src/utilities/get-template-entrypoints.js
+++ b/src/utilities/get-template-entrypoints.js
@@ -45,6 +45,30 @@ module.exports = function () {
 
     if (isValidTemplate(name) && fs.existsSync(jsFile)) {
       entrypoints[`template.${name}`] = jsFile;
+
+      // Always use main product template script file for duplicated product templates
+      // it is a feature required on some projects
+      // override as default product script
+      if (config.get('build.baseProductModule') && name.startsWith(`product.`)) {
+        const jsProductBaseFile = path.join(
+          config.get('theme.src.scripts'),
+          'templates',
+          'product.js',
+        );
+        entrypoints[`template.${name}`] = jsProductBaseFile;
+      }
+
+      // Always use main collection template script file for duplicated collection templates
+      // it is a feature required on some projects
+      // override as default collection script
+      if (config.get('build.baseCollectionModule') && name.startsWith(`collection.`)) {
+        const jsCollectionBaseFile = path.join(
+          config.get('theme.src.scripts'),
+          'templates',
+          'collection.js',
+        );
+        entrypoints[`template.${name}`] = jsCollectionBaseFile;
+      }
     }
   });
 


### PR DESCRIPTION
…on configuration

<!-- PULL REQUEST TEMPLATE -->

**What kind of change does this PR introduce?** (check at least one)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, _not_ the `master` branch

**Other information:**
Why this feature is required?

Some clients want to create duplicated product & collection templates with suffix like `product.test.json`, `collection.test.json`
But in duplicated templates script requires to be duplicated in matching script files like `product.test.js`, `colleciton.test.js` and it have to include duplicated script for pdp & collection which is not effective.

How resolved?

I have used configuration value for enable/disable this feature and if configuration is set, just applied base script `product.js` & `collection.js` to duplicated templates.

Please review and let me know your thoughts Eric.

Sincerely

Andy