### PR TITLE
packer ssl:make: fix timing bug

### DIFF
--- a/cli/__tests__/__snapshots__/ssl.test.js.snap
+++ b/cli/__tests__/__snapshots__/ssl.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test ssl command ssl:make creates some files in .localhost_ssl 1`] = `
+Array [
+  "ca.crt",
+  "ca.key",
+  "cert.crt",
+  "cert.key",
+]
+`;

--- a/cli/__tests__/ssl.test.js
+++ b/cli/__tests__/ssl.test.js
@@ -1,0 +1,33 @@
+/* eslint-env jest */
+const ssl = require('../commands/ssl');
+const mock = require('mock-fs');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+beforeAll(() => {
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+describe('Test ssl command', () => {
+  beforeEach(() => {
+    // Start with an empty file system
+    mock({});
+  });
+  afterEach(() => {
+    mock.restore();
+  });
+  test('ssl:make creates some files in .localhost_ssl', (done) => {
+    ssl({make: true})
+      .then(() => {
+        assertSnapshot(path.join(os.homedir(), '.localhost_ssl'));
+      })
+      .then(done);
+  });
+});
+
+function assertSnapshot(dir) {
+  const result = fs.readdirSync(dir);
+  mock.restore();
+  expect(result).toMatchSnapshot();
+}

--- a/cli/commands/ssl.js
+++ b/cli/commands/ssl.js
@@ -1,10 +1,10 @@
 const {checkSSL, validate} = require('../../src/server/ssl');
 
-module.exports = (args) => {
+module.exports = async (args) => {
   if (args.check) {
     validate();
   }
   if (args.make) {
-    checkSSL();
+    await checkSSL();
   }
 };

--- a/src/server/ssl.js
+++ b/src/server/ssl.js
@@ -55,7 +55,7 @@ function getSSL() {
   return {key, cert, ca};
 }
 
-function checkSSL() {
+async function checkSSL() {
   makeCertFolder();
 
   const writeCert = (cert, key) => {
@@ -72,13 +72,13 @@ function checkSSL() {
     console.log(
       'No Certificate Authority (CA) found. Creating one now to issue new SSL certificates'
     );
-    createCA()
+    await createCA()
       .then(({cert, key}) => writeCA(cert, key))
       .catch((err) => console.error(err));
   }
   if (!checkCert()) {
     console.log('No SSL Certificate found. Creating one now');
-    createCert()
+    await createCert()
       .then(({cert, key}) => writeCert(cert, key))
       .catch((err) => console.error(err));
   }


### PR DESCRIPTION
createCA() is async and thus doesn't finish till *after* it returns.
createCert() *needs* the CA file to exist before it runs.

If both files are missing, **this command died every time** because
`createCert()` would be called before the CA file was created.

It would then kill the node process before *either* file was created.

Now we use async/await to order them appropriately and we add a test to
ensure the files get created.

**What kind of change does this PR introduce?** (check at least one)
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [X] No

**The PR fulfills these requirements:**
- [X] It's submitted to the `dev` branch, _not_ the `master` branch

Thanks for working with me on this @masonmcelvain 