### PR TITLE
packer start: handle {file}.css.liquid correctly

### DIFF
--- a/src/server/asset/index.js
+++ b/src/server/asset/index.js
@@ -55,13 +55,15 @@ module.exports = class AssetServer {
     if (this._isLiquidTagFile(file) && this._hasAssetChanged(file, info)) {
       return this.updates.add(`snippets/${path.basename(file)}`);
     }
-    if (this._isLiquidFile(file) && this._hasAssetChanged(file, info)) {
-      return this.updates.add(
-        file.replace(`..${path.sep}`, '').replace(`../`, '')
-      );
-    }
-    if (this._isAssetFile(file) && this._hasAssetChanged(file, info)) {
-      return this.updates.add(`assets/${file}`);
+    if (
+      (this._isLiquidFile(file) || this._isAssetFile(file)) &&
+      this._hasAssetChanged(file, info)
+    ) {
+      // Note: dist/assets is the "main" output dir and all webpack dirs are
+      // relative to it. Examples:
+      // somefile -> assets/somefile
+      // ../snippets/template -> assets/../snippets/template ->  snippets/template
+      return this.updates.add(path.normalize(path.join('assets', file)));
     }
   }
 


### PR DESCRIPTION
somefile.css.liquid was being picked up as a "liquid" file and we
assumed it definitely *wasn't* in the dist/assets dir. This is sometimes
not true (we can have liquid files in the assets dir).

Since the paths we get are already relative to the assets dir, let's
just use path joining and normalization to handle those cases. All this
function can do is exclude some files, it can't move them. So we
shouldn't be trying to *create* new paths based on extensions.

Fixes #144

**What kind of change does this PR introduce?** (check at least one)
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [X] No

**The PR fulfills these requirements:**
- [X] It's submitted to the `dev` branch, _not_ the `master` branch

Thanks for working with me on this @masonmcelvain 