### PR TITLE
stylelint: report errors in the exitCode

### DIFF
--- a/src/linters/stylelint/index.js
+++ b/src/linters/stylelint/index.js
@@ -22,6 +22,11 @@ function stylelint({fix} = {}) {
   );
 }
 
+function handleLinterFailure(error) {
+  process.exitCode = 1
+  console.error(error);
+}
+
 module.exports.stylelint = stylelint;
 
 module.exports.runStylelint = function runStylelint() {
@@ -29,7 +34,7 @@ module.exports.runStylelint = function runStylelint() {
   try {
     stylelint();
   } catch (error) {
-    console.error(error);
+    handleLinterFailure(error);
   }
 };
 
@@ -38,6 +43,6 @@ module.exports.runStylelintFix = function runStylelintFix() {
   try {
     stylelint({fix: true});
   } catch (error) {
-    console.error(error);
+    handleLinterFailure(error);  
   }
 };


### PR DESCRIPTION
Without this flag, it's hard to determine programmatically (i.e. in CI) that our code didn't pass the linter.

<!-- PULL REQUEST TEMPLATE -->

**What kind of change does this PR introduce?** (check at least one)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, _not_ the `master` branch

**Other information:**
We're currently using `packer lint` in CI, and the command is reporting success even though there are style violations.

We can hack around this by inspecting console output, but this approach is cleaner.